### PR TITLE
Fix cases where IP address of process is a superset of the

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -67,9 +67,11 @@ if __name__ == "__main__":
                              "(%s)" % (node, node_api))
                 continue
 
+            ros_ip = node_api[7:] # strip http://
+            ros_ip = ros_ip.split(':')[0] # strip :<port>/
             local_node = "localhost" in node_api or \
                          "127.0.0.1" in node_api or \
-                         (this_ip is not None and this_ip in node_api) or \
+                         (this_ip is not None and this_ip == ros_ip) or \
                          subprocess.check_output("hostname").strip() \
                          in node_api
             if not local_node:


### PR DESCRIPTION
ip address of the host (e.g. host == 10.0.0.2 and process running
on 10.0.0.22)

# Conflicts:
#	monitor.py